### PR TITLE
Move genre to Game Design section, add theme and gameplay loop entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,14 @@ A browser-based single-player game built with modern web technologies.
 | Language | TypeScript | ✅ Decided |
 | Build Tool | Vite | ✅ Decided |
 | Architecture | Scene-based (Phaser built-in) | ✅ Decided |
+
+## Game Design
+
+| Area | Choice | Status |
+|------|--------|--------|
 | Genre | TBD | ⏳ Pending |
+| Theme / Setting | TBD | ⏳ Pending |
+| Core Gameplay Loop | TBD | ⏳ Pending |
 
 ## Project Structure
 


### PR DESCRIPTION
Separates game design decisions from the Tech Stack table in README.md:

- Moved **Genre** out of Tech Stack into a new **Game Design** section
- Added **Theme / Setting** and **Core Gameplay Loop** as pending items

Related issues: #3, #4, #5